### PR TITLE
schema display conditionally rendered

### DIFF
--- a/resources/views/purple-chrome.blade.php
+++ b/resources/views/purple-chrome.blade.php
@@ -22,17 +22,13 @@
             @if (config('app.env') !== 'production')
             <span class="badge badge-warning d-none d-sm-inline" style="font-size: large;">
                 <i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Environment: {{ config('app.env') }}
-                @if (auth()->user()->db_schema)
-                <br></br> Schema: {{ auth()->user()->db_schema }}
-                @endif
+                @includeIf('db-schema-display')
             </span>
 
             {{-- Need to format a bit differently for small screens, or it looks un-designed --}}
             <span class="badge badge-warning d-inline d-sm-none mx-auto my-2" style="font-size: large;">
                 <i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Environment: {{ config('app.env') }}
-                @if (auth()->user()->db_schema)
-                <br></br> Schema: {{ auth()->user()->db_schema }}
-                @endif
+                @includeIf('db-schema-display')
             </span>
             @endif
         </nav>

--- a/resources/views/purple-chrome.blade.php
+++ b/resources/views/purple-chrome.blade.php
@@ -22,11 +22,17 @@
             @if (config('app.env') !== 'production')
             <span class="badge badge-warning d-none d-sm-inline" style="font-size: large;">
                 <i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Environment: {{ config('app.env') }}
+                @if (auth()->user()->db_schema)
+                <br></br> Schema: {{ auth()->user()->db_schema }}
+                @endif
             </span>
 
             {{-- Need to format a bit differently for small screens, or it looks un-designed --}}
             <span class="badge badge-warning d-inline d-sm-none mx-auto my-2" style="font-size: large;">
                 <i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Environment: {{ config('app.env') }}
+                @if (auth()->user()->db_schema)
+                <br></br> Schema: {{ auth()->user()->db_schema }}
+                @endif
             </span>
             @endif
         </nav>


### PR DESCRIPTION
## Overview
- Conditionally rendered the database schema name to display it in all eCATS-UI pages
- This change is restricted to non-prod environments
![image](https://user-images.githubusercontent.com/46304788/107817899-5ff09600-6d3c-11eb-84d8-e88373009f40.png)

## Checklist
- [X] Successful local installment via composer
- [X] Successful eCATS-UI deployment via Jenkins
