### PR TITLE
SOAP-224 Enable Sentry APM JS

### DIFF
--- a/config/northwestern-theme.php
+++ b/config/northwestern-theme.php
@@ -15,4 +15,6 @@ return [
 
     // If specified, the Sentry browser SDK will be activated.
     'sentry-dsn' => env('SENTRY_LARAVEL_DSN', env('SENTRY_DSN')),
+    'sentry-enable-apm-js' => true,
+    'sentry-traces-sample-rate' => 0.05
 ];

--- a/config/northwestern-theme.php
+++ b/config/northwestern-theme.php
@@ -15,6 +15,6 @@ return [
 
     // If specified, the Sentry browser SDK will be activated.
     'sentry-dsn' => env('SENTRY_LARAVEL_DSN', env('SENTRY_DSN')),
-    'sentry-enable-apm-js' => true,
-    'sentry-traces-sample-rate' => 0.05
+    'sentry-enable-apm-js' => env('SENTRY_ENABLE_APM_FOR_JS', true),
+    'sentry-traces-sample-rate' => env('SENTRY_TRACES_SAMPLE_RATE', 0.0),
 ];

--- a/resources/views/purple-chrome.blade.php
+++ b/resources/views/purple-chrome.blade.php
@@ -112,7 +112,6 @@
         @if($sentry_config['enable_apm'])
             sentryConfig.integrations.push(new BrowserTracing())
         @endif
-            console.log(sentryConfig);
         Sentry.init(sentryConfig);
     </script>
     @endisset

--- a/resources/views/purple-chrome.blade.php
+++ b/resources/views/purple-chrome.blade.php
@@ -108,6 +108,10 @@
 
     @isset($sentry_config['dsn'])
     <script type="text/javascript">
+        const config = @json($sentry_config);
+        @if($sentry_config['enable_apm'])
+            config['integrations'].push(new BrowserTracing())
+        @endif
         Sentry.init(@json($sentry_config));
     </script>
     @endisset

--- a/resources/views/purple-chrome.blade.php
+++ b/resources/views/purple-chrome.blade.php
@@ -116,7 +116,7 @@
                 email: currentUser.email,
                 segment: currentUser.segment,
             });
-        @@endisset
+        @endisset
 
         const sentryConfig = @json($sentry_config);
 

--- a/resources/views/purple-chrome.blade.php
+++ b/resources/views/purple-chrome.blade.php
@@ -111,11 +111,7 @@
         @isset($user)
             const currentUser = @json($user);
 
-            Sentry.setUser({
-                username: currentUser.username,
-                email: currentUser.email,
-                segment: currentUser.segment,
-            });
+            Sentry.setUser(currentUser);
         @endisset
 
         const sentryConfig = @json($sentry_config);

--- a/resources/views/purple-chrome.blade.php
+++ b/resources/views/purple-chrome.blade.php
@@ -108,11 +108,12 @@
 
     @isset($sentry_config['dsn'])
     <script type="text/javascript">
-        const config = @json($sentry_config);
+        const sentryConfig = @json($sentry_config);
         @if($sentry_config['enable_apm'])
-            config['integrations'].push(new BrowserTracing())
+            sentryConfig.integrations.push(new BrowserTracing())
         @endif
-        Sentry.init(@json($sentry_config));
+            console.log(sentryConfig);
+        Sentry.init(sentryConfig);
     </script>
     @endisset
 

--- a/resources/views/purple-chrome.blade.php
+++ b/resources/views/purple-chrome.blade.php
@@ -111,7 +111,11 @@
         @isset($user)
             const currentUser = @json($user);
 
-            Sentry.setUser(currentUser);
+            Sentry.setUser({
+                    username: currentUser.username,
+                    email: currentUser.email,
+                    segment: currentUser.segment
+            });
         @endisset
 
         const sentryConfig = @json($sentry_config);

--- a/resources/views/purple-chrome.blade.php
+++ b/resources/views/purple-chrome.blade.php
@@ -108,10 +108,22 @@
 
     @isset($sentry_config['dsn'])
     <script type="text/javascript">
+        @isset($user)
+            const currentUser = @json($user);
+
+            Sentry.setUser({
+                username: currentUser.username,
+                email: currentUser.email,
+                segment: currentUser.segment,
+            });
+        @@endisset
+
         const sentryConfig = @json($sentry_config);
+
         @if($sentry_config['enable_apm'])
             sentryConfig.integrations.push(new BrowserTracing())
         @endif
+
         Sentry.init(sentryConfig);
     </script>
     @endisset

--- a/src/Helpers/UserContextGetter.php
+++ b/src/Helpers/UserContextGetter.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Northwestern\SysDev\UI\Helpers;
+
+class UserContextGetter
+{
+    public static function getUserContext()
+    {
+        $user = auth()->user();
+        $ip = request()->getClientIp();
+        $segment = null;
+
+        if (! $user) {
+            return;
+        }
+
+        $userClass = get_class($user);
+
+        if (method_exists($userClass, 'segment')) {
+            $segment = $user->segment();
+        }
+
+
+        return [
+            'id' => $user->id,
+            'username' => $user->username,
+            'email' => $user->email,
+            'ip' => $ip,
+            'primaryAffiliation' => $user->primary_affiliation,
+            'segment' => isset($segment) ? $segment : null,
+        ];
+    }
+}

--- a/src/Presets/northwestern-stubs/js/sentry.js
+++ b/src/Presets/northwestern-stubs/js/sentry.js
@@ -1,3 +1,5 @@
 
 import * as Sentry from '@sentry/browser';
+import { BrowserTracing } from "@sentry/tracing";
+window.BrowserTracing = BrowserTracing;
 window.Sentry = Sentry;

--- a/src/Providers/NorthwesternUiServiceProvider.php
+++ b/src/Providers/NorthwesternUiServiceProvider.php
@@ -51,6 +51,10 @@ class NorthwesternUiServiceProvider extends ServiceProvider
 
             $user = auth()->user();
 
+            if (! $user) {
+                return;
+            }
+
             $view->with('user', [
                 'username' => $user->username,
                 'email' => $user->email,

--- a/src/Providers/NorthwesternUiServiceProvider.php
+++ b/src/Providers/NorthwesternUiServiceProvider.php
@@ -48,6 +48,8 @@ class NorthwesternUiServiceProvider extends ServiceProvider
                 'enable_apm' => (bool)config('northwestern-theme.sentry-enable-apm-js'),
                 'tracesSampleRate' => config('northwestern-theme.sentry-traces-sample-rate'),
             ]);
+
+            $view->with('user', auth()->user());
         });
 
         Route::macro('sentryTunnel', function ($withoutMiddleware = [], $path = 'sentry/tunnel') {

--- a/src/Providers/NorthwesternUiServiceProvider.php
+++ b/src/Providers/NorthwesternUiServiceProvider.php
@@ -46,8 +46,7 @@ class NorthwesternUiServiceProvider extends ServiceProvider
                 'tunnel' => Route::has('sentry.tunnel') ? route('sentry.tunnel', [], false) : null,
                 'integrations' => [],
                 'enable_apm' => (bool)config('northwestern-theme.sentry-enable-apm-js'), // add to integrations in blade since it has to init js object
-//                'tracesSampleRate' => config('northwestern-theme.sentry-traces-sample-rate'),
-                'tracesSampleRate' => 1.0,
+                'tracesSampleRate' => config('northwestern-theme.sentry-traces-sample-rate'),
             ]);
         });
 

--- a/src/Providers/NorthwesternUiServiceProvider.php
+++ b/src/Providers/NorthwesternUiServiceProvider.php
@@ -49,7 +49,13 @@ class NorthwesternUiServiceProvider extends ServiceProvider
                 'tracesSampleRate' => config('northwestern-theme.sentry-traces-sample-rate'),
             ]);
 
-            $view->with('user', auth()->user());
+            $user = auth()->user();
+
+            $view->with('user', [
+                'username' => $user->username,
+                'email' => $user->email,
+                'segment' => $user->segment(),
+            ]);
         });
 
         Route::macro('sentryTunnel', function ($withoutMiddleware = [], $path = 'sentry/tunnel') {

--- a/src/Providers/NorthwesternUiServiceProvider.php
+++ b/src/Providers/NorthwesternUiServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\View;
 use Laravel\Ui\UiCommand;
+use Northwestern\SysDev\UI\Helpers\UserContextGetter;
 use Northwestern\SysDev\UI\Http\Controllers\SentryTunnelController;
 use Northwestern\SysDev\UI\Presets\Northwestern;
 
@@ -38,6 +39,8 @@ class NorthwesternUiServiceProvider extends ServiceProvider
         }
 
         View::composer('northwestern::purple-chrome', function ($view) {
+            $userContextGetter = new UserContextGetter();
+
             $view->with('load_livewire', $this->app->bound('livewire'));
 
             $view->with('sentry_config', [
@@ -49,17 +52,7 @@ class NorthwesternUiServiceProvider extends ServiceProvider
                 'tracesSampleRate' => config('northwestern-theme.sentry-traces-sample-rate'),
             ]);
 
-            $user = auth()->user();
-
-            if (! $user) {
-                return;
-            }
-
-            $view->with('user', [
-                'username' => $user->username,
-                'email' => $user->email,
-                'segment' => $user->segment(),
-            ]);
+            $view->with('user', $userContextGetter->getUserContext());
         });
 
         Route::macro('sentryTunnel', function ($withoutMiddleware = [], $path = 'sentry/tunnel') {

--- a/src/Providers/NorthwesternUiServiceProvider.php
+++ b/src/Providers/NorthwesternUiServiceProvider.php
@@ -46,8 +46,7 @@ class NorthwesternUiServiceProvider extends ServiceProvider
                 'tunnel' => Route::has('sentry.tunnel') ? route('sentry.tunnel', [], false) : null,
                 'integrations' => [],
                 'enable_apm' => (bool)config('northwestern-theme.sentry-enable-apm'), // add to integrations in blade since it has to init js object
-//                'tracesSampleRate' => config('northwestern-theme.sentry-traces-sample-rate'),
-                'tracesSampleRate' => 1.0,
+                'tracesSampleRate' => config('northwestern-theme.sentry-traces-sample-rate'),
             ]);
         });
 

--- a/src/Providers/NorthwesternUiServiceProvider.php
+++ b/src/Providers/NorthwesternUiServiceProvider.php
@@ -44,6 +44,10 @@ class NorthwesternUiServiceProvider extends ServiceProvider
                 'dsn' => config('northwestern-theme.sentry-dsn'),
                 'environment' => config('app.env'),
                 'tunnel' => Route::has('sentry.tunnel') ? route('sentry.tunnel', [], false) : null,
+                'integrations' => [],
+                'enable_apm' => (bool)config('northwestern-theme.sentry-enable-apm'), // add to integrations in blade since it has to init js object
+//                'tracesSampleRate' => config('northwestern-theme.sentry-traces-sample-rate'),
+                'tracesSampleRate' => 1.0,
             ]);
         });
 

--- a/src/Providers/NorthwesternUiServiceProvider.php
+++ b/src/Providers/NorthwesternUiServiceProvider.php
@@ -44,8 +44,8 @@ class NorthwesternUiServiceProvider extends ServiceProvider
                 'dsn' => config('northwestern-theme.sentry-dsn'),
                 'environment' => config('app.env'),
                 'tunnel' => Route::has('sentry.tunnel') ? route('sentry.tunnel', [], false) : null,
-                'integrations' => [],
-                'enable_apm' => (bool)config('northwestern-theme.sentry-enable-apm-js'), // add to integrations in blade since it has to init js object
+                'integrations' => [], // add to integrations in blade since it has to init js object
+                'enable_apm' => (bool)config('northwestern-theme.sentry-enable-apm-js'),
                 'tracesSampleRate' => config('northwestern-theme.sentry-traces-sample-rate'),
             ]);
         });

--- a/src/Providers/NorthwesternUiServiceProvider.php
+++ b/src/Providers/NorthwesternUiServiceProvider.php
@@ -45,8 +45,9 @@ class NorthwesternUiServiceProvider extends ServiceProvider
                 'environment' => config('app.env'),
                 'tunnel' => Route::has('sentry.tunnel') ? route('sentry.tunnel', [], false) : null,
                 'integrations' => [],
-                'enable_apm' => (bool)config('northwestern-theme.sentry-enable-apm'), // add to integrations in blade since it has to init js object
-                'tracesSampleRate' => config('northwestern-theme.sentry-traces-sample-rate'),
+                'enable_apm' => (bool)config('northwestern-theme.sentry-enable-apm-js'), // add to integrations in blade since it has to init js object
+//                'tracesSampleRate' => config('northwestern-theme.sentry-traces-sample-rate'),
+                'tracesSampleRate' => 1.0,
             ]);
         });
 


### PR DESCRIPTION
- setup to enable sentry APM on the frontend, used by SOAP but will continue to be disabled by default if you don't pass the config options to turn it on 
- still needs to be connected to the laravel APM trace and set up the user context to go through, split off a SOAP ticket for that since I don't have more time right now. 