### PR TITLE
Bootstrap 5 close button fix

### DIFF
--- a/resources/views/flash.blade.php
+++ b/resources/views/flash.blade.php
@@ -1,6 +1,6 @@
 @if (Session::has('status'))
 <div class="alert alert-info alert-dismissible fade show w-100" role="alert">
-  <button type="button" class="btn-close" data-dismiss="alert" aria-label="Close"></button>
+  <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
   {{ Session::get('status') }}
 </div>
 @endif

--- a/resources/views/flash.blade.php
+++ b/resources/views/flash.blade.php
@@ -1,8 +1,6 @@
 @if (Session::has('status'))
 <div class="alert alert-info alert-dismissible fade show w-100" role="alert">
-  <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-    <span aria-hidden="true">&times;</span>
-  </button>
+  <button type="button" class="btn-close" data-dismiss="alert" aria-label="Close"></button>
   {{ Session::get('status') }}
 </div>
 @endif


### PR DESCRIPTION
## Overview
Fixes an issue with the close button on the flash message due to a [breaking Bootstrap 5 change](https://getbootstrap.com/docs/5.0/migration/#close-button).

### Before
![2023-05-09_15 54 53_Microsoft Edge Dev](https://github.com/NIT-Administrative-Systems/northwestern-laravel-ui/assets/17434202/dbe53bf4-0932-4ced-8e55-9b5bc85d9996)


### After
![2023-05-09_15 55 03_Microsoft Edge Dev](https://github.com/NIT-Administrative-Systems/northwestern-laravel-ui/assets/17434202/acbfe0f4-71c7-4510-9642-2a7e3ae8ed3a)
