### PR TITLE
Fix active `nav-link` text color

### DIFF
--- a/src/Presets/northwestern-stubs/sass/nu_purple_layout.scss
+++ b/src/Presets/northwestern-stubs/sass/nu_purple_layout.scss
@@ -159,4 +159,8 @@ h4.head-section .btn-sm {
 //This overrides bootstrap default [color: hsla(0,0%,100%,.5);] for accessibility reasons
 .navbar-dark .navbar-nav .nav-link {
     color: hsla(0,0%,100%,.6);
+    
+    &.active {
+        color: #fff;
+    }
 }


### PR DESCRIPTION
With the `.active` class on a `.nav-link`, the existing `.navbar-dark .navbar-nav .nav-link` selector would override the text color Bootstrap would attempt to apply. This is likely related to changes in BS5 since I don't see this behavior in applications using lower versions.