### PR TITLE
Support additional flash keys, correct misspelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Corrected a misspelling of `Police` to `Policies` in the footer.
+- Bootstrap 5 compatability issues with the `demo-styles` view.
 
 ## [v2.1.0] - 2023-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+- Support for additional flash keys with contextual styling.
+
+### Fixed
+- Corrected a misspelling of `Police` to `Policies` in the footer.
+
+## [v2.1.0] - 2023-06-13
+
+### Added
+- **Global Alert** component.
+
+### Changed
+- Defined the text color for the `.nav-link:active` state.
+
+### Fixed
+- Updated the namespace on a Bootstrap 5 data attribute in the `northwestern::flash` component.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Corrected a misspelling of `Police` to `Policies` in the footer.
 - Bootstrap 5 compatability issues with the `demo-styles` view.
+- Alignment issues with the `northwestern::errors` component.
 
 ## [v2.1.0] - 2023-06-13
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,13 +71,6 @@ Route::get('/demo', function () {
 ```
 
 ## Upgrading
-### v2.1.0
-This release introduces a Global Alert component and fixes some Bootstrap 5 compatibility issues.
-
-See [the section on Global Alerts](usage.md#global-alerts) for more information on using this feature.
-
-There are no breaking changes in this release.
-
 ### v2.0.0
 This version drops support for Laravel Mix and Bootstrap 4. Laravel Vite and Bootstrap 5 are supported, and the layout has been adjusted accordingly.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -143,7 +143,27 @@ It has some boilerplate text and an icon, giving you a standard look for form va
 ![Form validation summary](./assets/error.png)
 
 ## Flash Messages
-[Flash messages](https://laravel.com/docs/7.x/session#flash-data) for the `status` key will be displayed automatically by both layouts.
+[Flash messages](https://laravel.com/docs/10.x/session#flash-data) are used to provide feedback to the user and will be displayed automatically by both layouts.
+
+The following flash keys are supported:
+
+- `status-info`
+- `status-success`
+- `status-warning`
+- `status-danger`
+- `status`
+
+By default, if only the `status` key is set, it will be displayed as an informational message (i.e., `status-info`).
+
+Each flash key corresponds to a specific [Bootstrap contextual style](https://getbootstrap.com/docs/5.0/components/alerts/#examples) and a [FontAwesome](https://fontawesome.com/v6/search) icon:
+
+| Flash Key        | Bootstrap Style | FontAwesome Icon                                                                                     |
+|------------------|-----------------|------------------------------------------------------------------------------------------------------|
+| `status-info`    | `alert-info`    | [`fa-circle-info`](https://fontawesome.com/v6/icons/circle-info?f=classic&s=solid)                   |
+| `status-success` | `alert-success` | [`fa-circle-check`](https://fontawesome.com/v6/icons/circle-check?f=classic&s=solid)                 |
+| `status-warning` | `alert-warning` | [`fa-triangle-exclamation`](https://fontawesome.com/v6/icons/triangle-exclamation?f=classic&s=solid) |
+| `status-danger`  | `alert-danger`  | [`fa-circle-exclamation`](https://fontawesome.com/v6/icons/circle-exclamation?f=classic&s=solid)     |
+| `status`         | `alert-info`    | [`fa-circle-info`](https://fontawesome.com/v6/icons/circle-info?f=classic&s=solid)                   |
 
 ## Global Alerts
 Global Alerts allow you to display a message at the top of every page. This can be useful for planned outages, announcements, or other important information.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -153,7 +153,7 @@ The following flash keys are supported:
 - `status-danger`
 - `status`
 
-By default, if only the `status` key is set, it will be displayed as an informational message (i.e., `status-info`).
+By default, if only the `status` key is set, it will be displayed as an informational message (i.e., `alert-info`).
 
 Each flash key corresponds to a specific [Bootstrap contextual style](https://getbootstrap.com/docs/5.0/components/alerts/#examples) and a [FontAwesome](https://fontawesome.com/v6/search) icon:
 

--- a/resources/views/demo-styles.blade.php
+++ b/resources/views/demo-styles.blade.php
@@ -46,21 +46,21 @@ $errors = new Illuminate\Support\MessageBag(['first_name' => 'The first name fie
         <span class="badge badge-secondary badge-pill">3</span>
         </h4>
         <ul class="list-group mb-3">
-        <li class="list-group-item d-flex justify-content-between lh-condensed">
+        <li class="list-group-item d-flex justify-content-between lh-sm">
             <div>
             <h6 class="my-0">Product name</h6>
             <small class="text-muted">Brief description</small>
             </div>
             <span class="text-muted">$12</span>
         </li>
-        <li class="list-group-item d-flex justify-content-between lh-condensed">
+        <li class="list-group-item d-flex justify-content-between lh-sm">
             <div>
             <h6 class="my-0">Second product</h6>
             <small class="text-muted">Brief description</small>
             </div>
             <span class="text-muted">$8</span>
         </li>
-        <li class="list-group-item d-flex justify-content-between lh-condensed">
+        <li class="list-group-item d-flex justify-content-between lh-sm">
             <div>
             <h6 class="my-0">Third item</h6>
             <small class="text-muted">Brief description</small>
@@ -83,9 +83,7 @@ $errors = new Illuminate\Support\MessageBag(['first_name' => 'The first name fie
         <form class="card p-2">
         <div class="input-group">
             <input type="text" class="form-control" placeholder="Promo code">
-            <div class="input-group-append">
             <button type="submit" class="btn btn-secondary">Redeem</button>
-            </div>
         </div>
         </form>
     </div>
@@ -114,9 +112,7 @@ $errors = new Illuminate\Support\MessageBag(['first_name' => 'The first name fie
         <div class="mb-3">
             <label for="username" class="required">Username</label>
             <div class="input-group">
-            <div class="input-group-prepend">
                 <span class="input-group-text">@</span>
-            </div>
             <input type="text" class="form-control" id="username" placeholder="Username" required>
             <div class="invalid-feedback" style="width: 100%;">
                 Your username is required.
@@ -148,7 +144,7 @@ $errors = new Illuminate\Support\MessageBag(['first_name' => 'The first name fie
         <div class="row">
             <div class="col-md-5 mb-3">
             <label for="country" class="required">Country</label>
-            <select class="custom-select d-block w-100" id="country" required>
+            <select class="form-select" id="country" required>
                 <option value="">Choose...</option>
                 <option>United States</option>
             </select>
@@ -158,7 +154,7 @@ $errors = new Illuminate\Support\MessageBag(['first_name' => 'The first name fie
             </div>
             <div class="col-md-4 mb-3">
             <label for="state" class="required">State</label>
-            <select class="custom-select d-block w-100" id="state" required>
+            <select class="form-select" id="state" required>
                 <option value="">Choose...</option>
                 <option>California</option>
             </select>
@@ -175,30 +171,30 @@ $errors = new Illuminate\Support\MessageBag(['first_name' => 'The first name fie
             </div>
         </div>
         <hr class="mb-4">
-        <div class="custom-control custom-checkbox">
-            <input type="checkbox" class="custom-control-input" id="same-address">
-            <label class="custom-control-label" for="same-address">Shipping address is the same as my billing address</label>
+        <div class="form-check">
+            <input type="checkbox" class="form-check-input" id="same-address">
+            <label class="form-check-label" for="same-address">Shipping address is the same as my billing address</label>
         </div>
-        <div class="custom-control custom-checkbox">
-            <input type="checkbox" class="custom-control-input" id="save-info">
-            <label class="custom-control-label" for="save-info">Save this information for next time</label>
+        <div class="form-check">
+            <input type="checkbox" class="form-check-input" id="save-info">
+            <label class="form-check-label" for="save-info">Save this information for next time</label>
         </div>
         <hr class="mb-4">
 
         <h4 class="mb-3">Payment</h4>
 
         <div class="d-block my-3">
-            <div class="custom-control custom-radio">
-            <input id="credit" name="paymentMethod" type="radio" class="custom-control-input" checked required>
-            <label class="custom-control-label" for="credit">Credit card</label>
+            <div class="form-check">
+                <input id="credit" name="paymentMethod" type="radio" class="form-check-input" checked required>
+                <label class="form-check-label" for="credit">Credit card</label>
             </div>
-            <div class="custom-control custom-radio">
-            <input id="debit" name="paymentMethod" type="radio" class="custom-control-input" required>
-            <label class="custom-control-label" for="debit">Debit card</label>
+            <div class="form-check">
+                <input id="debit" name="paymentMethod" type="radio" class="form-check-input" required>
+                <label class="form-check-label" for="debit">Debit card</label>
             </div>
-            <div class="custom-control custom-radio">
-            <input id="paypal" name="paymentMethod" type="radio" class="custom-control-input" required>
-            <label class="custom-control-label" for="paypal">PayPal</label>
+            <div class="form-check">
+                <input id="paypal" name="paymentMethod" type="radio" class="form-check-input" required>
+                <label class="form-check-label" for="paypal">PayPal</label>
             </div>
         </div>
         <div class="row">
@@ -371,7 +367,7 @@ $errors = new Illuminate\Support\MessageBag(['first_name' => 'The first name fie
     </table>
 </div>
 <div class="d-flex justify-content-end">
-    {{ new \Illuminate\Pagination\LengthAwarePaginator([], 1000, 25, 3) }}
+    {{ new \Illuminate\Pagination\LengthAwarePaginator(collect(range(51, 75)), 1000, 25, 3) }}
 </div>
 
 @endsection

--- a/resources/views/errors.blade.php
+++ b/resources/views/errors.blade.php
@@ -1,7 +1,9 @@
 @if ($errors->any())
 <div class="alert alert-danger {{ isset($form_error_class) ? $form_error_class : ''}}">
-    <i class="fa fa-exclamation float-left pr-3" style="font-size: 48pt;" aria-hidden="true"></i>
-    <p style="font-size: 16pt"><strong>Oops</strong>, there was an issue with that.</p>
+	<div class="d-flex align-items-center">
+		<i class="fa fa-exclamation me-3" style="font-size: 48pt;" aria-hidden="true"></i>
+		<p class="mb-0" style="font-size: 16pt"><strong>Oops</strong>, there was an issue with that.</p>
+	</div>
 	<ul class="ml-5">
 		@foreach ($errors->all() as $error)
 			<li>{{ $error }}</li>

--- a/resources/views/flash.blade.php
+++ b/resources/views/flash.blade.php
@@ -1,6 +1,28 @@
-@if (Session::has('status'))
-<div class="alert alert-info alert-dismissible fade show w-100" role="alert">
-  <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-  {{ Session::get('status') }}
-</div>
+@php
+    /*
+     * Determine the alert type and contextual icon based on a populated session key.
+     *
+     * Default to "info" for backward compatibility (versions < v2.1.0)
+     */
+    $statusDefinitions = collect([
+        'status-info' => ['type' => 'info', 'icon' => 'circle-info'],
+        'status-success' => ['type' => 'success', 'icon' => 'circle-check'],
+        'status-warning' => ['type' => 'warning', 'icon' => 'triangle-exclamation'],
+        'status-danger' => ['type' => 'danger', 'icon' => 'circle-exclamation'],
+        'status' => ['type' => 'info', 'icon' => 'circle-info'],
+    ]);
+
+    $currentStatus = $statusDefinitions->first(fn($definition, $key) => session()->has($key));
+
+    $statusType = $currentStatus['type'] ?? null;
+    $statusIcon = $currentStatus['icon'] ?? null;
+@endphp
+
+@if ($statusType && $statusIcon)
+    <div class="alert alert-{{ $statusType }} alert-dismissible fade show w-100" role="alert">
+        <i class="fas fa-{{ $statusIcon }} me-1" aria-hidden="true"></i>
+        {{-- Retrieve the specific status type value, or 'status' as a fallback --}}
+        {{ session('status-' . $statusType, session('status')) }}
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
 @endif

--- a/resources/views/purple-chrome.blade.php
+++ b/resources/views/purple-chrome.blade.php
@@ -70,7 +70,7 @@
                 <li><a href='https://www.northwestern.edu/hr/careers/'>Careers</a></li>
                 <li><a href='https://www.northwestern.edu/disclaimer.html'>Disclaimer</a></li>
                 <li><a href='https://www.northwestern.edu/emergency/index.html'>Campus Emergency Information</a></li>
-                <li><a href='https://policies.northwestern.edu/'>University Police</a></li>
+                <li><a href='https://policies.northwestern.edu/'>University Policies</a></li>
                 <li><a href='https://www.northwestern.edu/accessibility/about/report-accessibility-issue.html'>Report an Accessibility Issue</a></li>
             </ul>
         </div>


### PR DESCRIPTION
This pull request primarily adds support for additional flash keys when rendering alerts, along with a few minor changes.

> [!IMPORTANT]  
> Backward compatability is maintained for existing dependents by defaulting to `alert-info` if the session key of `status` is available.

### Added
- `CHANGELOG.md`
- Support for additional flash keys with contextual styling.

### Changed
- Removed `v2.1.0` from the upgrade guide in the VuePress site since it's only relevant for the changelog.

### Fixed
- Corrected a misspelling of `Police` to `Policies` in the footer.
- Bootstrap 5 compatibility issues with the `demo-styles` view.
- Alignment issues with the `northwestern::errors` component.