### PR TITLE
Update Sentry SDK to v4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Breaking Change
+This release now requires the underlying [Sentry PHP SDK v4.0](https://github.com/getsentry/sentry-php). Please refer to the PHP SDK [sentry-php/UPGRADE-4.0.md](https://github.com/getsentry/sentry-php/blob/master/UPGRADE-4.0.md) guide for a complete list of breaking changes.
+
+- `@sentry/browser` should be updated to a minimum version of `7.100.0`. Please refer to the [migration guide](https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md) for a complete list of breaking changes.
+- `@sentry/tracing` is no longer required and can be removed from your project if it is not otherwise used.
+
 ## [v2.2.0] - 2023-08-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 This release now requires the underlying [Sentry PHP SDK v4.0](https://github.com/getsentry/sentry-php). Please refer to the PHP SDK [sentry-php/UPGRADE-4.0.md](https://github.com/getsentry/sentry-php/blob/master/UPGRADE-4.0.md) guide for a complete list of breaking changes.
 
 - `@sentry/browser` should be updated to a minimum version of `7.100.0`. Please refer to the [migration guide](https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md) for a complete list of breaking changes.
+  - If you are using the `resources/js/sentry.js` file from this package, [review the new version](./src/Presets/northwestern-stubs/js/sentry.js). 
 - `@sentry/tracing` is no longer required and can be removed from your project if it is not otherwise used.
 
 ## [v2.2.0] - 2023-08-31

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
         "laravel/ui": "^3.0|^2.0|^3.0|^4.0",
-        "sentry/sdk": "^3"
+        "sentry/sdk": "^4"
     },
     "require-dev": {
         "orchestra/testbench": "^8.0",

--- a/resources/views/purple-chrome.blade.php
+++ b/resources/views/purple-chrome.blade.php
@@ -124,7 +124,7 @@
             const sentryConfig = @json($sentry_config);
 
             @if($sentry_config['enable_apm'])
-                sentryConfig.integrations.push(new BrowserTracing())
+                sentryConfig.integrations.push(Sentry.browserTracingIntegration())
             @endif
 
             Sentry.init(sentryConfig);

--- a/src/Presets/Northwestern.php
+++ b/src/Presets/Northwestern.php
@@ -22,8 +22,7 @@ class Northwestern extends Presets\Preset
     {
         return [
             '@fortawesome/fontawesome-free' => '^6.4.0',
-            '@sentry/browser' => '^7.38.0',
-            '@sentry/tracing' => '^7.30.0',
+            '@sentry/browser' => '^7.100.0',
         ] + $packages;
     }
 

--- a/src/Presets/northwestern-stubs/js/sentry.js
+++ b/src/Presets/northwestern-stubs/js/sentry.js
@@ -1,5 +1,4 @@
 
 import * as Sentry from '@sentry/browser';
-import { BrowserTracing } from "@sentry/tracing";
-window.BrowserTracing = BrowserTracing;
+
 window.Sentry = Sentry;


### PR DESCRIPTION
Updating the Sentry SDK to version 4, along with the corresponding changes to the browser dependencies.